### PR TITLE
Fix missing audio when GPT replies lack punctuation

### DIFF
--- a/aigirlfriend.py
+++ b/aigirlfriend.py
@@ -156,6 +156,8 @@ def stream_gpt_response_and_play() -> str:
     print(f"🧠 Nova (full): {full_text}")
 
     sentences = re.findall(r'[^.!?]+[.!?]"?', full_text, re.DOTALL)
+    if not sentences:
+        sentences = [full_text]
     audio_queue = queue.Queue()
 
     def play_audio_worker():


### PR DESCRIPTION
## Summary
- prevent silent replies when GPT output has no sentence-ending punctuation

## Testing
- `python -m py_compile aigirlfriend.py`
