### PR TITLE
fix: prevent clipping of first word in streamed audio

### DIFF
--- a/aigirlfriend.py
+++ b/aigirlfriend.py
@@ -94,6 +94,9 @@ def play_audio_stream(audio_stream):
                     channels=1,
                     rate=24000,
                     output=True)
+    # Prime the audio output with a brief silence to prevent the first
+    # chunk from being clipped when the device starts. 4800 bytes ~=0.1s.
+    stream.write(b"\x00" * 4800)
     for chunk in audio_stream.iter_bytes(chunk_size=1024):
         stream.write(chunk)
     stream.stop_stream()


### PR DESCRIPTION
## Summary
- prevent first word of streamed responses from being clipped by priming audio output with brief silence

## Testing
- `python -m py_compile aigirlfriend.py utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68b995f53ea0832489e5c89bcc8f4353